### PR TITLE
Add seed argument to random functions

### DIFF
--- a/test/clatrix/core_test.clj
+++ b/test/clatrix/core_test.clj
@@ -264,3 +264,6 @@
   (expect (Math/sinh 7.0)   (c/get (c/sinh! (c/column (range 9))) 7 0))
   (expect (Math/sqrt 7.0)   (c/get (c/sqrt! (c/column (range 9))) 7 0))
   (expect (Math/tanh 7.0)   (c/get (c/tanh! (c/column (range 9))) 7 0)))
+
+(expect 2.0498889512140543
+        (c/trace (c/with-seed 42 (c/rand 5 5))))


### PR DESCRIPTION
Sometimes this is handy for generating repeatable sequences of pseudo-random
numbers (like in tests or for demonstration purposes.)
