### PR TITLE
Add a travis configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: clojure
+lein: lein2
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq libgfortran3
+script: lein2 expectations
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+
+
+


### PR DESCRIPTION
Hello!
This pull request would add a [Travis](https://www.travis-ci.org) configuration file, so that tests get run automatically on a Travis computer every time a commit gets pushed.

(you would also need to 
- log in to Travis with Github OAuth,
- go to your profile page, 
- flip clatrix's switch on,
- copy your token string and finally
- go to the github service hooks page and paste your username and Travis token string [as explained much more eloquently here)](http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in)

I would also like to ask whether a stable version that includes `clatrix.core/det` is coming out soon. :smiling_imp: 

Cheers!
