### PR TITLE
Make Matrix and Vector Reversible

### DIFF
--- a/src/clatrix/core.clj
+++ b/src/clatrix/core.clj
@@ -78,6 +78,11 @@
   (empty [this]
     (matrix []))
 
+  clojure.lang.Reversible
+  (rseq [this]
+    "Return a reverse seq of rows for a 2D or a reverse seq of entries for a 1D matrix"
+    (seq (reverse this)))
+
   clojure.lang.Counted  ;; The number of rows for a matrix, or elems for a vector
   (count [this]
     (if (vector-matrix? this)
@@ -132,6 +137,11 @@
 
   (empty [this]
     (matrix []))
+
+  clojure.lang.Reversible
+  (rseq [this]
+    "Return a reverse seq of entries for a 1D matrix"
+    (seq (reverse this)))
 
   clojure.lang.Counted  ;; The number of rows for a matrix, or elems for a vector
   (count [this]

--- a/test/clatrix/core_test.clj
+++ b/test/clatrix/core_test.clj
@@ -162,6 +162,11 @@
          (c/matrix [6 21 36 51 66 81 96 111 126 141])]
         (c/cols F [4 7 6]))
 
+;; clojure reverse methods
+(expect (c/vector [3 2 1]) (rseq V))
+(expect (c/column (reverse (range n))) (rseq C))
+(expect (c/matrix [[4 5 6] [1 2 3]]) (rseq M))
+
 ;; properties of id
 (given (c/eye n)
        (expect c/size [n n]


### PR DESCRIPTION
Add clojure.core.Reversible to Matrix and Vector.  The helps facilitate
writing code that is agnostic to whether you are using a clatrix object
or a native Clojure vector or list.
