### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,4 +11,5 @@
                  [slingshot "0.10.3"]
                  [org.jblas/jblas "1.2.3"]
                  [net.mikera/core.matrix "0.7.1"]]
-  :profiles {:dev {:dependencies [[expectations "1.4.16"]]}})
+  :profiles {:dev {:dependencies [[criterium/criterium "0.4.1"]
+                                  [expectations "1.4.41"]]}})


### PR DESCRIPTION
Updated dependencies for latest core.matrix

This is a prerequisite for getting core.matrix to work with Incanter
