### PR TITLE
Positive definite test for matrixes, `maybe-positive`, corrected

### DIFF
--- a/src/clatrix/core.clj
+++ b/src/clatrix/core.clj
@@ -202,7 +202,7 @@
   (cond
     (matrix? m) [(nrows m) (ncols m)]
     (vec? m) [(nrows m)]
-    (m/array? m) (m/shape m) 
+    (m/array? m) (m/shape m)
     :else (throw (IllegalArgumentException. "Not a Vector or Matrix"))))
 (defn vector-matrix?
   "Is m nx1 or 1xn"
@@ -788,14 +788,10 @@ Uses the same algorithm as java's default Random constructor."
     (if (symmetric? m)
       ;; We'll have faster access to the eigenvalues later...
       (let [vals (dotom Eigen/eigenvalues m)
-            rvals (seq (.toArray (.real vals)))
-            ivals (seq (.toArray (.real vals)))
-            mags (clojure.core/map #(Math/sqrt
-                                      (clojure.core/+ (Math/pow %1 2)
-                                                      (Math/pow %2 2))) rvals ivals)]
-        (if (every? #(> % 0) mags)
+            rvals (seq (.toArray (.real vals)))]
+        (if (every? #(> % 0) rvals)
           (positive m)
-          m))
+          (with-meta m {:positive false})))
       m)))
 
 ;;; # Functor operations

--- a/test/clatrix/core_test.clj
+++ b/test/clatrix/core_test.clj
@@ -26,6 +26,15 @@
 (def ridx (range n))
 (def cidx (range m))
 
+; neither symmetric nor positive
+(def notsym (c/matrix [[1 2] [3 4]]))
+; symmetric but not positive
+(def symmat
+  (let [m (c/matrix [[2 1] [1 -2]])]
+    (c/+ m (c/t m))))
+; symmetric and positive
+(def posmat (c/* symmat (c/t symmat)))
+
 ;; properties of A/S
 (expect Matrix A)
 (expect Matrix B)
@@ -131,6 +140,16 @@
 
 ;; equality
 (expect R (range m))
+
+;; symmetry and positivity
+(expect false (c/symmetric? (c/maybe-symmetric M)))
+(expect false (c/symmetric? (c/maybe-symmetric p)))
+(expect false (c/symmetric? (c/maybe-symmetric notsym)))
+
+(expect false (c/positive? (c/maybe-positive symmat)))
+
+(expect true (c/symmetric? (c/maybe-symmetric symmat)))
+(expect true (c/positive? (c/maybe-positive posmat)))
 
 ;; clojure sequence methods
 (expect (c/matrix [(range 1 m)]) (rest R))


### PR DESCRIPTION
Added tests for maybe-symmetric and maybe-positive. Corrected maybe-positive now fails on non-positive matrixes because it's checking for positivity of the matrix's eigenvalues' real components (not their magnitudes).
