### PR TITLE
Added wrapper for jblas' `solveLeastSquares` to clatrix as `lm` (a la R)

### DIFF
--- a/src/clatrix/core.clj
+++ b/src/clatrix/core.clj
@@ -202,7 +202,7 @@
   (cond
     (matrix? m) [(nrows m) (ncols m)]
     (vec? m) [(nrows m)]
-    (m/array? m) (m/shape m) 
+    (m/array? m) (m/shape m)
     :else (throw (IllegalArgumentException. "Not a Vector or Matrix"))))
 (defn vector-matrix?
   "Is m nx1 or 1xn"
@@ -1010,8 +1010,8 @@ Uses the same algorithm as java's default Random constructor."
       A)))
 
 (defn solve
-  "`solve` solves the equation `Ax = B` for the column `Matrix`
-  `x`. Positivity and symmetry hints on `A` will cause `solve` to use
+  "`solve` solves the equation `A X = B` for the `Matrix` `X`.
+  Positivity and symmetry hints on `A` will cause `solve` to use
   optimized LAPACK routines."
   [^Matrix A ^Matrix B]
   (matrix
@@ -1023,6 +1023,14 @@ Uses the same algorithm as java's default Random constructor."
       :else          (Solve/solve ^DoubleMatrix (me A)
                                   ^DoubleMatrix (me B)))
     ))
+
+(defn lm
+  "`lm` computes the ordinary least squares solution `A X = B` for an
+  over- or under-determined system of linear equations using the QR
+  decomposition."
+  [^Matrix A ^Matrix B]
+  (matrix (Solve/solveLeastSquares ^DoubleMatrix (me A)
+                                   ^DoubleMatrix (me B))))
 
 (defn i
   "`i` computes the inverse of a matrix. This is done via Gaussian

--- a/src/clatrix/core.clj
+++ b/src/clatrix/core.clj
@@ -1026,8 +1026,8 @@ Uses the same algorithm as java's default Random constructor."
 
 (defn lm
   "`lm` computes the ordinary least squares solution `A X = B` for an
-  over- or under-determined system of linear equations using the QR
-  decomposition."
+  over- or under-determined system of linear equations using the SVD
+  (singular value decomposition)."
   [^Matrix A ^Matrix B]
   (matrix (Solve/solveLeastSquares ^DoubleMatrix (me A)
                                    ^DoubleMatrix (me B))))

--- a/test/clatrix/core_test.clj
+++ b/test/clatrix/core_test.clj
@@ -26,6 +26,16 @@
 (def ridx (range n))
 (def cidx (range m))
 
+(def mat (c/rnorm 3 3))
+(def v (c/rnorm 3 3))
+
+(defn normerr [x y]
+  (let [num (c/norm (c/- x y))
+        den (c/norm x)
+        eps (Math/ulp 1.0)]
+    (/ num (if (> den 0) den eps))))
+(defn float0? [x & {:keys [base] :or {base 1.0}}] (< x (Math/ulp base)))
+
 ;; properties of A/S
 (expect Matrix A)
 (expect Matrix B)
@@ -252,6 +262,10 @@
 (expect (c/matrix [[1 4 9] [16 25 36]]) (c/mult M M))
 (expect (c/matrix [[0.5 1.0 1.5] [2.0 2.5 3.0]]) (c/div M 2))
 (expect (c/constant 2 3 1.0) (c/div M M))
+
+;; linear systems
+(expect true (float0? (normerr (c/* mat (c/solve mat v)) v) :base 1e2))
+(expect true (float0? (normerr (c/* mat (c/lm mat v)) v) :base 1e2))
 
 ;; LU decomposition
 (let [lu (c/lu B)]


### PR DESCRIPTION
While clatrix's `solve` can only be used for *solving* linear systems AX=B (i.e., A must be square), this new `lm` function finds good solutions to AX=B for arbitrary A using jblas' `solveLeastSquares` function. This uses the QR decomposition to find the min-norm (under-determined system, fat A) or least squares (over-determined system, tall A) solution. Also includes basic tests for both `solve` and `lm`.

I called it `lm` because that's what R calls it ("linear model"). I'm open to alternatives.

(Hope to push this functionality to Incanter so it can do ordinary least squares respectably.)