### PR TITLE
add better performing 'mget' for 1D and 2D matrices, update core.matrix ...

### DIFF
--- a/src/clatrix/core.clj
+++ b/src/clatrix/core.clj
@@ -202,7 +202,7 @@
   (cond
     (matrix? m) [(nrows m) (ncols m)]
     (vec? m) [(nrows m)]
-    (m/array? m) (m/shape m) 
+    (m/array? m) (m/shape m)
     :else (throw (IllegalArgumentException. "Not a Vector or Matrix"))))
 (defn vector-matrix?
   "Is m nx1 or 1xn"
@@ -243,6 +243,11 @@
        (if (number? out)
          out
          (matrix out)))))
+
+(defmacro mget
+  "Faster implementation of `get`, a single value by indices only."
+  ([m r] `(dotom .get ~m ~r))
+  ([m r c] `(dotom .get ~m ~r ~c)))
 
 (defn set
   ([^Matrix m ^long r ^long c ^double e]
@@ -1381,8 +1386,8 @@ Uses the same algorithm as java's default Random constructor."
                                             (throw (IllegalArgumentException. "Matrix only has dimensions 0 and 1")))))
 
   mp/PIndexedAccess
-  (get-1d [m i] (get m i))
-  (get-2d [m row column] (get m row column))
+  (get-1d [m i] (mget m i))
+  (get-2d [m row column] (mget m row column))
   (get-nd [m indexes]
     (let [dims (count indexes)]
       (if (== dims 2)
@@ -1529,8 +1534,8 @@ Uses the same algorithm as java's default Random constructor."
                                             (throw (IllegalArgumentException. "Vector only has dimension 0")))))
 
   mp/PIndexedAccess
-  (get-1d [m i] (get m i))
-  (get-2d [m row column] (get m row column))
+  (get-1d [m i] (mget m i))
+  (get-2d [m row column] (mget m row column))
   (get-nd [m indexes]
     (let [dims (count indexes)]
       (if (== dims 1)

--- a/test/clatrix/core_test.clj
+++ b/test/clatrix/core_test.clj
@@ -1,8 +1,11 @@
 (ns clatrix.core-test
   (:use expectations)
-  (:require [clatrix.core :as c])
+  (:require [clatrix.core :as c]
+            [criterium.core :as crit])
   (:import [clatrix.core Matrix Vector]
            [java.io StringReader PushbackReader]))
+
+(def ^:dynamic *bench* false)
 
 (defn read* [str]
   (read (PushbackReader. (StringReader. str))))
@@ -115,6 +118,17 @@
 (let [z (rand)]
   (c/set A 0 0 z)
   (expect z (c/get A 0 0)))
+
+(expect 1.0 (c/mget V 0))
+(expect 3.0 (c/mget V 2))
+
+(expect 2.0 (c/mget M 0 1))
+(expect 6.0 (c/mget M 1 2))
+
+(if (true? *bench*)
+  (do
+    (crit/bench (dotimes [i n] (dotimes [j m] (c/mget F i j))))
+    (crit/bench (dotimes [i n] (dotimes [j m] (c/get F i j))))))
 
 ;; Check idempotence of matrix constructor
 (expect A (c/matrix (c/matrix A) :unused-arg :another-unused-arg))


### PR DESCRIPTION
Introducing a special case 'get' function named 'mget' for 1D and 2D matrices and update on core.matrix/PIndexedAccess. Unit test and benchmark (default 'off') included.
