### PR TITLE
mmul on vectors fixed

### DIFF
--- a/src/clatrix/core.clj
+++ b/src/clatrix/core.clj
@@ -987,6 +987,7 @@ Uses the same algorithm as java's default Random constructor."
                    (Vector. (.transpose
                               (.mmul (.transpose ^DoubleMatrix (me a)) ^DoubleMatrix (me b))) nil)
                    (matrix (dotom .mmul b (double a))))
+               (and (vec? a) (vec? b)) (mp/vector-dot a b)
                :else       (clojure.core/* a b)))
   ([a b & as] (reduce * a (cons b as))))
 

--- a/test/clatrix/matrix_api_test.clj
+++ b/test/clatrix/matrix_api_test.clj
@@ -35,6 +35,8 @@
     (is (m/equals m (m/add m 0)))
     (is (m/equals m (m/mul m 1)))
     (is (m/equals [50 110] (m/mmul m v)))
+    (is (m/equals [[7.0 10.0] [15.0 22.0]] (m/mmul m m)))
+    (is (m/equals 500 (m/mmul v v)))
     (is (m/equals [[1.0 (/ 2.0)] [(/ 3.0) (/ 4.0)]] (m/div m)))
     (is (m/equals [[1 1] [1 1]] (m/div m m)))))
 


### PR DESCRIPTION
Currently, `*` appied to 2 vectors raises

``` Clojure
ClassCastException clatrix.core.Vector cannot be cast to java.lang.Number  clojure.lang.Numbers.multiply (Numbers.java:146)
```

This PR fixes the problem and returns dot product of these vectors.
