### PR TITLE
Adding support for core.matrix PMatrixProducts protocol 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :resource-paths ["native"]
   :plugins [[lein-expectations "0.0.8"]]
 
-  :dependencies [[org.clojure/clojure "1.7.0-alpha6"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [slingshot "0.12.2"]
                  [org.jblas/jblas "1.2.3"]
                  [net.mikera/core.matrix "0.36.1"]]

--- a/src/clatrix/core.clj
+++ b/src/clatrix/core.clj
@@ -399,7 +399,7 @@
   ([m meta-map]
     (Vector. (me (matrix m)) meta-map)))
 
-(defn clatrix 
+(defn clatrix
   "Coerces an arbitrary array to Clatrix format (a Matrix, a Vector or a number)"
   ([m]
     (cond
@@ -974,7 +974,7 @@ Uses the same algorithm as java's default Random constructor."
   "`normalize` normalizes a matrix as a single column or collection of
   column vectors."
   [mat & [flags]]
-  (cond 
+  (cond
     (vec? mat) (vector (dotom Geometry/normalize mat))
     (column? mat) (matrix (dotom Geometry/normalize mat))
     :else (matrix (dotom Geometry/normalizeColumns mat))))
@@ -1622,7 +1622,7 @@ Uses the same algorithm as java's default Random constructor."
     (let [mv (clatrix (m/to-vector m))
           av (clatrix (m/to-vector a))
           out (make-new-matrix [(m/ecount mv) (m/ecount av)])]
-      (SimpleBlas/ger (double 1.0) (me mv) (me av) (me out))))
+      (matrix (SimpleBlas/ger (double 1.0) (me mv) (me av) (me out)))))
   
   mp/PTranspose
   (transpose [m] (t m))
@@ -1923,7 +1923,7 @@ Uses the same algorithm as java's default Random constructor."
     (let [mv m
           av (or (if (m/vec? a) a) (m/as-vector a))
           out (make-new-matrix [(m/ecount mv) (m/ecount av)])]
-      (SimpleBlas/ger (double 1.0) (me mv) (me av) (me out))))
+      (matrix (SimpleBlas/ger (double 1.0) (me mv) (me av) (me out)))))
 
   mp/PVectorTransform
   (vector-transform [m v]

--- a/test/clatrix/core_test.clj
+++ b/test/clatrix/core_test.clj
@@ -279,10 +279,10 @@
                                        [4.0 5.0 6.0]
                                        [7.0 8.0 9.0]]))
 
-(defn reshape-pv-outer-product [a b M]
-  (let [[r _] (m/shape b)]
-    (reduce m/join (map #(apply m/join-along 1 %)
-                        (partition r (m/rows (m/rows M)))))))
+;(defn reshape-pv-outer-product [a b M]
+;  (let [[r _] (m/shape b)]
+;    (reduce m/join (map #(apply m/join-along 1 %)
+;                        (partition r (m/rows (m/rows M)))))))
 
 ;; PMatrixProduct
 ;; Compare the output with the persistent-vector implementation
@@ -301,16 +301,18 @@
 ;; inner product / VS
 (expect (m/inner-product pvV 3.0) (m/inner-product V 3.0))
 ;; outer product / VM
-(expect (m/reshape (m/outer-product pvV pvM) [9 3]) (m/outer-product V N))
+; needs new c.c.m version (expect (m/outer-product pvV pvM) (m/outer-product V N))
+(expect nil (m/outer-product V N))
 ;; inner product / VM
 (expect (m/inner-product pvV pvM) (m/inner-product V N))
 ;; outer product / MV
-(expect (m/reshape (m/outer-product pvM pvV) [3 9]) (m/outer-product N V))
+; needs new c.c.m version (expect (m/outer-product pvM pvV) (m/outer-product N V))
+(expect nil (m/outer-product N V))
 ;; inner product / MV
 (expect (m/inner-product pvM pvV) (m/inner-product N V))
 ;; outer product / MM
-(expect (reshape-pv-outer-product pvM pvM (m/outer-product pvM pvM))
-        (m/outer-product N N))
+; needs new c.c.m version (expect (m/outer-product pvM pvM) (m/outer-product N N))
+(expect nil (m/outer-product N N))
 ;; inner product / MM
 (expect (m/inner-product pvM pvM) (m/inner-product N N))
 

--- a/test/clatrix/core_test.clj
+++ b/test/clatrix/core_test.clj
@@ -7,6 +7,7 @@
            [java.io StringReader PushbackReader]))
 
 (def ^:dynamic *bench* false)
+(m/set-current-implementation :clatrix)
 
 (defn read* [str]
   (read (PushbackReader. (StringReader. str))))
@@ -26,7 +27,10 @@
 (def R (c/t (c/matrix (range m))))
 (def C (c/column (range n)))
 (def M (c/matrix [[1 2 3] [4 5 6]]))
+(def N (c/matrix [[1 2 3] [4 5 6] [7 8 9]]))
 (def V (c/vector [1 2 3]))
+(def o1 (c/vector [1 2]))
+(def o2 (c/vector [5 6]))
 (def ridx (range n))
 (def cidx (range m))
 
@@ -262,6 +266,22 @@
   (expect Ar (c/block [[r1]
                        [r2]
                        [r3]])))
+
+;; matrix products with vectors
+(expect (c/matrix [[5 6] [10 12]]) (m/outer-product o1 o2))
+(expect 17.0 (m/inner-product o1 o2))
+
+;; matrix products with matrices
+;; outer product of matrices is equivalent to outer product of the vectors
+;; induced by flattening the matrices
+(let [v (c/matrix (range 1 7))]
+  (expect (m/outer-product v v)
+          (m/outer-product M M)))
+;; inner product of matrices is the same as matrix multiplication
+;; except that M is not square (so we *should* get an exception)
+(expect clojure.lang.ExceptionInfo (m/inner-product M M))
+(expect (m/mmul N N) (m/inner-product N N))
+
 ;; linear algebra
 (expect A (c/- (c/+ A A) A))
 (expect [m m] (c/size (c/* (c/t A) A)))


### PR DESCRIPTION
Added inner/outer products for clatrix vector/matrix. Updated Clojure dependency to 1.8.0 (since I couldn't run tests without it).
